### PR TITLE
Update time and tests

### DIFF
--- a/R/functions_wmm.R
+++ b/R/functions_wmm.R
@@ -228,7 +228,10 @@ GetMagneticFieldWMM <- function(
 
   if (!is.numeric(time)) {
     if (inherits(time, c("POSIXt", "Date"))) {
-      YrJul <- with(as.POSIXlt(time), c(1900 + year, yday))
+      YrJul <- with(
+        as.POSIXlt(time),
+        c(1900 + year, yday + hour/24 + min/1440 + sec/86400)
+      )
       # https://www.timeanddate.com/date/leapyear.html#rules
       leapyear <- +((YrJul[1] %% 4 == 0) & ((!YrJul[1] %% 100 == 0) | (YrJul[1] %% 400 == 0)))
       ydays <- 365 + leapyear

--- a/R/functions_wmm.R
+++ b/R/functions_wmm.R
@@ -143,7 +143,7 @@
 #' @param lon GPS longitude
 #' @param lat GPS latitude, geodetic
 #' @param height GPS height in meters above ellipsoid
-#' @param time Annualized date time. E.g., 2015-02-01 = (2015 + 32/365) = 2015.088
+#' @param time Annualized date time. E.g., 2015-02-01 = (2015 + 32/365) = 2015.088; optionally an object (length 1) of class 'POSIXt' or 'Date'
 #' @param wmmVersion String representing WMM version to use. Must be consistent with \code{time} and one of the following: 'derived', 'WMM2000', 'WMM2005', 'WMM2010', 'WMM2015', 'WMM2015v2', 'WMM2020'. Default 'derived' value will infer the latest WMM version consistent with \code{time}.
 #'
 #' @return \code{list} of calculated main field and secular variation vector components in nT and nT/yr, resp. The magnetic element intensities (i.e., horizontal and total intensities, h & f) are in nT and the magnetic element angles (i.e., inclination and declination, i & d) are in degrees, with their secular variation in nT/yr and deg/yr, resp.: \code{x}, \code{y}, \code{z}, \code{xDot}, \code{yDot}, \code{zDot}, \code{h}, \code{f}, \code{i}, \code{d}, \code{hDot}, \code{fDot}, \code{iDot}, \code{dDot}
@@ -225,6 +225,16 @@ GetMagneticFieldWMM <- function(
   wmmVersion = 'derived'
 ) {
   geocentric <- .ConvertGeodeticToGeocentricGPS(lat, height)
+
+  if (!is.numeric(time)) {
+    if (inherits(time, c("POSIXt", "Date"))) {
+      YrJul <- with(as.POSIXlt(time), c(1900 + year, yday))
+      ydays <- if (all(YrJul[1] %% c(4, 100, 400) == 0)) 366 else 365
+      time <- YrJul[1] + YrJul[2]/ydays
+    } else {
+      stop("unrecognized 'time': ", paste(sQuote(class(time)), collapse = ", "))
+    }
+  }
 
   output <- .CalculateMagneticField(
     lon = lon,

--- a/R/functions_wmm.R
+++ b/R/functions_wmm.R
@@ -229,7 +229,8 @@ GetMagneticFieldWMM <- function(
   if (!is.numeric(time)) {
     if (inherits(time, c("POSIXt", "Date"))) {
       YrJul <- with(as.POSIXlt(time), c(1900 + year, yday))
-      leapyear <- +((year %% 4 == 0) & ((!year %% 100 == 0) | (year %% 400 == 0)))
+      # https://www.timeanddate.com/date/leapyear.html#rules
+      leapyear <- +((YrJul[1] %% 4 == 0) & ((!YrJul[1] %% 100 == 0) | (YrJul[1] %% 400 == 0)))
       ydays <- 365 + leapyear
       time <- YrJul[1] + YrJul[2]/ydays
     } else {

--- a/R/functions_wmm.R
+++ b/R/functions_wmm.R
@@ -229,7 +229,8 @@ GetMagneticFieldWMM <- function(
   if (!is.numeric(time)) {
     if (inherits(time, c("POSIXt", "Date"))) {
       YrJul <- with(as.POSIXlt(time), c(1900 + year, yday))
-      ydays <- if (all(YrJul[1] %% c(4, 100, 400) == 0)) 366 else 365
+      leapyear <- +((year %% 4 == 0) & ((!year %% 100 == 0) | (year %% 400 == 0)))
+      ydays <- 365 + leapyear
       time <- YrJul[1] + YrJul[2]/ydays
     } else {
       stop("unrecognized 'time': ", paste(sQuote(class(time)), collapse = ", "))

--- a/man/GetMagneticFieldWMM.Rd
+++ b/man/GetMagneticFieldWMM.Rd
@@ -13,7 +13,7 @@ GetMagneticFieldWMM(lon, lat, height, time, wmmVersion = "derived")
 
 \item{height}{GPS height in meters above ellipsoid}
 
-\item{time}{Annualized date time. E.g., 2015-02-01 = (2015 + 32/365) = 2015.088}
+\item{time}{Annualized date time. E.g., 2015-02-01 = (2015 + 32/365) = 2015.088; optionally an object (length 1) of class 'POSIXt' or 'Date'}
 
 \item{wmmVersion}{String representing WMM version to use. Must be consistent with \code{time} and one of the following: 'derived', 'WMM2000', 'WMM2005', 'WMM2010', 'WMM2015', 'WMM2015v2', 'WMM2020'. Default 'derived' value will infer the latest WMM version consistent with \code{time}.}
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,20 @@
+# Define path to WMM test data
+folderExtdata <- file.path(
+  system.file(package = 'wmm'),
+  'extdata'
+)
+
+pathTestData <- file.path(
+  folderExtdata,
+  'WMMTestValues.csv'
+)
+
+# Import WMM test data
+testData <- data.table::fread(
+  pathTestData,
+  sep = '|',
+  header = TRUE,
+  stringsAsFactors = FALSE
+)[
+  , testID := .I
+]

--- a/tests/testthat/test-time-options.R
+++ b/tests/testthat/test-time-options.R
@@ -1,0 +1,41 @@
+testthat::context("Testing 'time' alternatives")
+
+testthat::test_that("'time' options are the same", {
+  dat <- testData[ h > 6000, ][ 1, ]
+
+  orig <- expect_silent(
+    dat[
+      , GetMagneticFieldWMM(
+        lon = lon,
+        lat = lat,
+        height = height * 1e3,
+        time = floor(year),
+        wmmVersion = wmmVersion
+      )]
+  )
+
+  posix <- expect_silent(
+    dat[
+      , GetMagneticFieldWMM(
+        lon = lon,
+        lat = lat,
+        height = height * 1e3,
+        time = as.POSIXct(paste0(floor(dat$year), "-01-01")),
+        wmmVersion = wmmVersion
+      )]
+  )
+
+  date <- expect_silent(
+    dat[
+      , GetMagneticFieldWMM(
+        lon = lon,
+        lat = lat,
+        height = height * 1e3,
+        time = as.Date(paste0(floor(dat$year), "-01-01")),
+        wmmVersion = wmmVersion
+      )]
+  )
+
+  expect_identical(orig, posix)
+  expect_identical(orig, date)
+})

--- a/tests/testthat/testWMM.R
+++ b/tests/testthat/testWMM.R
@@ -1,26 +1,5 @@
 testthat::context('Testing WMM...')
 
-# Define path to WMM test data
-folderExtdata <- file.path(
-  system.file(package = 'wmm'),
-  'extdata'
-)
-
-pathTestData <- file.path(
-  folderExtdata,
-  'WMMTestValues.csv'
-)
-
-# Import WMM test data
-testData <- data.table::fread(
-  pathTestData,
-  sep = '|',
-  header = TRUE,
-  stringsAsFactors = FALSE
-)[
-  , testID := .I
-]
-
 # Define character vectors used for unit tests, which may be changed
 keyFields <- c('testID', 'wmmVersion')
 vectorFields <- c('x', 'y', 'z')

--- a/tests/testthat/testWMM.R
+++ b/tests/testthat/testWMM.R
@@ -32,17 +32,63 @@ testFields <- c(
 calculatedFields <- paste0(testFields, 'Calculated')
 testthatFields <- c(keyFields, testFields)
 
-# Calculate magnetic field values
-testData[
-  , (calculatedFields) := GetMagneticFieldWMM(
-    lon = lon,
-    lat = lat,
-    height = height * 1e3,
-    time = year,
-    wmmVersion = wmmVersion
-  )
-  , by = testID
-]
+# Calculate magnetic field values, warning about 'is in'
+testthat::test_that("warns: is in the blackout zone", {
+  for (rn in which(testData$h < 2000)) {
+    testthat::expect_warning(
+      testData[
+        rn
+        , (calculatedFields) := GetMagneticFieldWMM(
+          lon = lon,
+          lat = lat,
+          height = height * 1e3,
+          time = year,
+          wmmVersion = wmmVersion
+        )
+        , by = testID
+      ]
+     , "Location is in the blackout zone")
+  }
+})
+
+# Calculate magnetic field values, warning about 'is approaching'
+testthat::test_that("warns: is approaching the blackout zone", {
+  for (rn in which(testData$h >= 2000 & testData$h < 6000)) {
+    testthat::expect_warning(
+      testData[
+        rn
+        , (calculatedFields) := GetMagneticFieldWMM(
+          lon = lon,
+          lat = lat,
+          height = height * 1e3,
+          time = year,
+          wmmVersion = wmmVersion
+        )
+        , by = testID
+      ]
+     , "Location is approaching the blackout zone")
+  }
+})
+
+# Calculate magnetic field values, no warning
+testthat::test_that("no warnings", {
+  testthat::expect_silent(
+    testData[
+      h >= 6000
+      , (calculatedFields) := GetMagneticFieldWMM(
+        lon = lon,
+        lat = lat,
+        height = height * 1e3,
+        time = year,
+        wmmVersion = wmmVersion
+      )
+      , by = testID
+    ])
+})
+
+testthat::test_that("nothing missed", {
+  expect_false(anyNA(testData[, c(calculatedFields), with = FALSE]))
+})
 
 # Copy table to help with set of test fields
 calculatedData <- data.table::copy(testData)[


### PR DESCRIPTION
This PR proposes two changes:

- allow `GetMagneticFieldWMM(..., time=)` to accept `POSIXt` and `Date` objects, internally converted to year-fraction
- update tests so that warnings are expected and less noisy

(The boundaries on `$h` for the warnings were grabbed from https://www.ngdc.noaa.gov/geomag/WMM/limit.shtml, I hope that's correct. It correctly identified all of the warnings here, so at least it's a good start.)